### PR TITLE
compute ranks of margin samples on-the-fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ StarVine provides tools to construct canonical and regular-vines
 
 StarVine can also be used as a standalone copula fitting tool for bivariate modeling.
 
+The following bivariate copula families are built-in:
+
+    - Gauss
+    - Student-t
+    - Frank
+    - Gumbel
+    - Clayton
+    - Marshall-Olkin
+
+All copula orientations are implemented.
+
+![image1](https://github.com/wgurecky/starvine/blob/master/doc/images/montage_copula_pdf_small.png)
+
+StarVine can also be used to fit and sample C-Vine:
+
+![image2](https://github.com/wgurecky/starvine/blob/master/doc/images/sm_scatter-2.png)
+
 Install
 ========
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ StarVine can also be used as a standalone copula fitting tool for bivariate mode
 
 The following bivariate copula families are built-in:
 
-    - Gauss
-    - Student-t
-    - Frank
-    - Gumbel
-    - Clayton
-    - Marshall-Olkin
+- Gauss
+- Student-t
+- Frank
+- Gumbel
+- Clayton
+- Marshall-Olkin
 
 All copula orientations are implemented.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numba
 numpy
 scipy
 emcee

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def setup_package():
           install_requires=['numpy>=1.8.0', 'scipy>=0.13',
                             'pandas>=0.13.0', 'h5py>=2.2.0',
                             'seaborn>=0.7.0', 'networkx>=2.0.0',
-                            'emcee>=2.0.0', 'statsmodels'],
+                            'emcee>=2.0.0', 'statsmodels', 'numba'],
           package_data={'': ['*.txt']},
           license='BSD-3clause',
           author_email='william.gurecky@utexas.edu',

--- a/starvine/bvcopula/copula/copula_base.py
+++ b/starvine/bvcopula/copula/copula_base.py
@@ -403,8 +403,8 @@ class CopulaBase(object):
         except:
             kc_out = []
             # create u, v grid
-            u = np.random.uniform(0, 1, int(1e3))
-            v = np.random.uniform(0, 1, int(1e3))
+            u = np.random.uniform(0, 1, int(8e3))
+            v = np.random.uniform(0, 1, int(8e3))
             u_hat, v_hat = self._ppf(u, v, self.rotation, *theta)
             cdf_int = self._cdf(u_hat, v_hat, self.rotation, *theta)
             for t in t_in:

--- a/starvine/bvcopula/copula/copula_base.py
+++ b/starvine/bvcopula/copula/copula_base.py
@@ -403,8 +403,8 @@ class CopulaBase(object):
         except:
             kc_out = []
             # create u, v grid
-            u = np.random.uniform(0, 1, int(8e3))
-            v = np.random.uniform(0, 1, int(8e3))
+            u = np.random.uniform(0, 1, int(2e4))
+            v = np.random.uniform(0, 1, int(2e4))
             u_hat, v_hat = self._ppf(u, v, self.rotation, *theta)
             cdf_int = self._cdf(u_hat, v_hat, self.rotation, *theta)
             for t in t_in:

--- a/starvine/bvcopula/copula/copula_base.py
+++ b/starvine/bvcopula/copula/copula_base.py
@@ -291,10 +291,12 @@ class CopulaBase(object):
         cll = self._nlogLike(u, v, wgts, rotation, *theta)
         if len(theta) == 1:
             # 1 parameter copula
-            AIC = 2 * cll + 2.0 + 4.0 / (len(u) - 2)
+            # AIC = 2 * cll + 2.0 + 4.0 / (len(u) - 2)
+            AIC = 2 * cll + 2.0 * np.log(len(u)) * 1
         else:
             # 2 parameter copula
-            AIC = 2 * cll + 4.0 + 12.0 / (len(u) - 3)
+            # AIC = 2 * cll + 4.0 + 12.0 / (len(u) - 3)
+            AIC = 2 * cll + 2.0 * np.log(len(u)) * 2
         return AIC
 
     def _gen(self, t, *theta):
@@ -406,8 +408,8 @@ class CopulaBase(object):
         except:
             kc_out = []
             # create u, v grid
-            u = np.random.uniform(0, 1, int(4e5))
-            v = np.random.uniform(0, 1, int(4e5))
+            u = np.random.uniform(0, 1, int(1e3))
+            v = np.random.uniform(0, 1, int(1e3))
             u_hat, v_hat = self._ppf(u, v, self.rotation, *theta)
             cdf_int = self._cdf(u_hat, v_hat, self.rotation, *theta)
             for t in t_in:

--- a/starvine/bvcopula/copula/copula_base.py
+++ b/starvine/bvcopula/copula/copula_base.py
@@ -236,7 +236,7 @@ class CopulaBase(object):
         @brief Default negative log likelyhood function.
         Used in MLE fitting
         """
-        return -self._logLike(u, v, wgts, rotation, *theta)
+        return -1.0 * self._logLike(u, v, wgts, rotation, *theta)
 
     def _logLike(self, u, v, wgts=None, rotation=0, *theta):
         """!
@@ -289,15 +289,10 @@ class CopulaBase(object):
         """
         wgts = kwargs.pop("weights", np.ones(len(u)))
         cll = self._nlogLike(u, v, wgts, rotation, *theta)
-        if len(theta) == 1:
-            # 1 parameter copula
-            # AIC = 2 * cll + 2.0 + 4.0 / (len(u) - 2)
-            AIC = 2 * cll + 2.0 * np.log(len(u)) * 1
-        else:
-            # 2 parameter copula
-            # AIC = 2 * cll + 4.0 + 12.0 / (len(u) - 3)
-            AIC = 2 * cll + 2.0 * np.log(len(u)) * 2
-        return AIC
+        k = len(self.theta0)
+        AIC = 2 * cll + 2.0 * k
+        AICc = AIC + (2. * k ** 2. + 2. * k) / (len(u) - k - 1)
+        return AICc
 
     def _gen(self, t, *theta):
         """!

--- a/starvine/bvcopula/copula/gumbel_copula.py
+++ b/starvine/bvcopula/copula/gumbel_copula.py
@@ -78,10 +78,22 @@ class GumbelCopula(CopulaBase):
         """
         U = np.array(u)
         V = np.array(v)
-        uu = np.zeros(U.size)
-        for i, (ui, vi) in enumerate(zip(U, V)):
-            uu[i] = self._invhfun_bisect(ui, vi, rotation, *theta)
-        return uu
+        # uu = np.zeros(U.size)
+        # for i, (ui, vi) in enumerate(zip(U, V)):
+        #     uu[i] = self._invhfun_bisect(ui, vi, rotation, *theta)
+        # return uu
+        # Apply rotation
+        if rotation == 1:
+            U = 1. - U
+        elif rotation == 3:
+            V = 1. - V
+        elif rotation == 0:
+            pass
+        vv = self.vec_newton_hinv(V, U, theta[0], z_init=np.ones(len(U)))
+        if rotation == 1 or rotation == 3:
+            return 1. - vv
+        else:
+            return vv
 
     @CopulaBase._rotGen
     def _gen(self, t, *theta):
@@ -93,3 +105,34 @@ class GumbelCopula(CopulaBase):
             return -1. * (1. - 1. / theta[0])
         else:
             return 1. - 1. / theta[0]
+
+    @staticmethod
+    def vec_newton_hinv(u, p, theta, z_init, under_relax=0.5, eps=1e-6, iter_max=100):
+        """!
+        @brief Finds the zero of h() via vectorized newtons method.
+            Note: For derivation of h() and h'() See:
+            Dependence Modeling with Copulas. H. Joe. pp 172.
+        @param u np_1darray in (0, 1)
+        @param p np_1darray in (0, 1)
+        @param theta float. copula shape parameter
+        @param z_init np_1darray initial guess for zeros
+        @param under_relax  float.
+        @param eps Convergence tol
+        """
+        x = - np.log(u)
+        h = lambda z: z + (theta - 1.) * np.log(z) - (x + (theta - 1.) * np.log(x) - np.log(p))
+        h_prime = lambda z: 1. + (theta - 1.0) / z
+        z = np.asarray(z_init)
+        i = 0
+        # z_old = np.ones(len(z)) * 1e12
+        # mask = np.empty(len(z), dtype=bool)
+        while i < iter_max:
+            # eps_arr = z - z_old
+            # mask = eps > np.abs(eps_arr)
+            z -= under_relax * h(z) / h_prime(z)
+            z = np.clip(z, 1e-12, 1e5)
+            # z_old = deepcopy(z)
+            i += 1
+        y = (z ** theta - x ** theta) ** (1. / theta)
+        vv = np.exp(-y)
+        return vv

--- a/starvine/bvcopula/pc_base.py
+++ b/starvine/bvcopula/pc_base.py
@@ -188,8 +188,6 @@ class PairCopula(object):
                 goldCopula = copula
                 goldParams = fittedCopulaParams
                 best_kc = trial_kc_metric
-            else:
-                raise RuntimeError("ERROR: Supply vaild criterion: AIC or Kc")
         #
         if vb: print("ID: %s. %s copula selected.  fitted params="
                      % (str(self.id), goldCopula.name) + str(goldParams[1])

--- a/starvine/bvcopula/pc_base.py
+++ b/starvine/bvcopula/pc_base.py
@@ -259,7 +259,11 @@ class PairCopula(object):
         @param copula starvine.bvcopula.copula.copula_base.CopulaBase instance
         """
         # rotate current data into the proposed copula orientation
-        rt_UU, rt_VV = self.rotate_data(self.UU, self.VV, copula.rotation)
+        if copula.name in ["gauss", "t"] and copula.rotation == 0 and self.empKTau_ < 0:
+            # force positive correlation
+            rt_UU, rt_VV = self.rotate_data(self.UU, self.VV, -1)
+        else:
+            rt_UU, rt_VV = self.rotate_data(self.UU, self.VV, copula.rotation)
         # compute emperical Kc on the rotated data
         rt_t_emp, rt_kc_emp = self.empKc(rt_UU, rt_VV)
         # fit the un-rotated copula

--- a/starvine/bvcopula/pc_base.py
+++ b/starvine/bvcopula/pc_base.py
@@ -73,7 +73,10 @@ class PairCopula(object):
         # store new weights and samples
         rx, ry = self.x[resample_idx], self.y[resample_idx]
         self.weights = np.ones(len(rx))
-        self.x, self.y = rx, ry
+        # add tiny gaussian noise to prevent ties
+        # TODO: check if this is required
+        gauss_noise = np.random.normal(loc=0, scale=1e-12, size=len(rx))
+        self.x, self.y = rx + gauss_noise, ry + gauss_noise
 
     def rank(self, method=0):
         """!

--- a/starvine/bvcopula/tests/test_multifit.py
+++ b/starvine/bvcopula/tests/test_multifit.py
@@ -34,3 +34,12 @@ class TestBivariateBase(unittest.TestCase):
 
         # Check gaussian copula parameters for correctness
         self.assertAlmostEqual(stockModel.copulaParams[1], 0.73874003, 4)
+
+        # Test kendalls criterion on rotated data
+        stockModel.setRotation(3)
+        stockModel.copulaTournament(criterion='Kc')
+
+        # When using kendalls criterion the predicted copula should be gumbel
+        self.assertTrue(stockModel.copulaModel.name == "gumbel")
+        self.assertTrue(stockModel.copulaParams[0] == "gumbel")
+        self.assertTrue(stockModel.copulaModel.rotation == 3)

--- a/starvine/bvcopula/tests/test_multifit.py
+++ b/starvine/bvcopula/tests/test_multifit.py
@@ -35,11 +35,36 @@ class TestBivariateBase(unittest.TestCase):
         # Check gaussian copula parameters for correctness
         self.assertAlmostEqual(stockModel.copulaParams[1], 0.73874003, 4)
 
-        # Test kendalls criterion on rotated data
-        stockModel.setRotation(3)
-        stockModel.copulaTournament(criterion='Kc')
+        # Test kendalls criterion on original data
+        stockModel.copulaTournament(criterion='Kc', log=True)
 
         # When using kendalls criterion the predicted copula should be gumbel
         self.assertTrue(stockModel.copulaModel.name == "gumbel")
         self.assertTrue(stockModel.copulaParams[0] == "gumbel")
-        self.assertTrue(stockModel.copulaModel.rotation == 3)
+        self.assertTrue(stockModel.copulaModel.rotation == 0)
+
+        # Rotate the data and test kendalls criteron again
+        stockModelNegative = PairCopula(-1 * x, y)
+        empTau = stockModelNegative.empKTau()[0]
+        self.assertTrue(empTau < 0)
+
+        # Test kendalls criterion on original data
+        stockModelNegative.copulaTournament(criterion='Kc')
+
+        # When using kendalls criterion the predicted copula should be gumbel
+        self.assertTrue(stockModelNegative.copulaModel.name == "gumbel")
+        self.assertTrue(stockModelNegative.copulaParams[0] == "gumbel")
+        self.assertTrue(stockModelNegative.copulaModel.rotation == 1)
+
+        # Rotate the data and test kendalls criteron again
+        stockModelNegative = PairCopula(x, -1 * y)
+        empTau = stockModelNegative.empKTau()[0]
+        self.assertTrue(empTau < 0)
+
+        # Test kendalls criterion on original data
+        stockModelNegative.copulaTournament(criterion='Kc')
+
+        # When using kendalls criterion the predicted copula should be gumbel
+        self.assertTrue(stockModelNegative.copulaModel.name == "gumbel")
+        self.assertTrue(stockModelNegative.copulaParams[0] == "gumbel")
+        self.assertTrue(stockModelNegative.copulaModel.rotation == 3)

--- a/tests/test_weighted_reg.py
+++ b/tests/test_weighted_reg.py
@@ -31,6 +31,7 @@ class TestWeightedReg(unittest.TestCase):
         Combine weighted samples into a single "X" shaped distribution.
         Refit weighted samples and ensure positive depencence
         """
+        np.random.seed(123)
         # construct gaussian margins; mu={0, 0}, sd={1.0, 2}
         marg1 = Uvm("gauss")(1e-3, 1.)
         marg2 = Uvm("gauss")(1e-3, 2.)
@@ -43,7 +44,7 @@ class TestWeightedReg(unittest.TestCase):
         cop2 = Copula("gauss")
         cop2.fittedParams = [-0.7]
 
-        # draw 1000 samples from each model
+        # draw 4000 samples from each model
         n = 4000
         x1, y1 = cop1.sampleScale(marg1, marg2, n)
         x2, y2 = cop2.sampleScale(marg1, marg2, n)
@@ -82,3 +83,53 @@ class TestWeightedReg(unittest.TestCase):
         given samples with unequal weights.
         """
         pass
+
+    def testWgtResampledCopula(self):
+        """!
+        @brief Test ability to construct copula
+        given samples with unequal weights using a resampling strat
+        """
+        np.random.seed(123)
+        # construct gaussian margins; mu={0, 0}, sd={1.0, 2}
+        marg1 = Uvm("gauss")(1e-3, 1.)
+        marg2 = Uvm("gauss")(1e-3, 2.)
+
+        # construct gaussian copula positive dep
+        cop1 = Copula("gauss")
+        cop1.fittedParams = [0.7]
+
+        # construct gaussian copula neg dep
+        cop2 = Copula("gauss")
+        cop2.fittedParams = [-0.7]
+
+        # draw 1000 samples from each model
+        n = 1000
+        x1, y1 = cop1.sampleScale(marg1, marg2, n)
+        x2, y2 = cop2.sampleScale(marg1, marg2, n)
+
+        # assign weights to each gauss sample group
+        cop1_wgts = np.ones(n) * 0.95
+        cop2_wgts = np.ones(n) * 0.05
+
+        # combine both gauss models into dbl gauss model
+        x = np.append(x1, x2)
+        y = np.append(y1, y2)
+        wgts = np.append(cop1_wgts, cop2_wgts)
+
+        # fit copula to weighted data
+        copModel = PairCopula(x, y, wgts, resample=10)
+        copModel.copulaTournament()
+
+        resampled_data = pd.DataFrame([copModel.x, copModel.y]).T
+        matrixPairPlot(resampled_data, savefig='x_gauss_resampled.png')
+
+        # verify that a positive dep copula was produced with a
+        # dep parameter of slightly less than 0.7
+        x_wt, y_wt = copModel.copulaModel.sampleScale(marg1, marg2, n)
+        self.assertTrue(copModel.copulaModel.kTau() > 0.)
+        self.assertTrue((copModel.copulaModel.fittedParams[0] > 0.)
+                        & (copModel.copulaModel.fittedParams[0] < 0.7))
+
+        # plot
+        data = pd.DataFrame([x_wt, y_wt]).T
+        matrixPairPlot(data, savefig='x_gauss_resampled_fit.png')

--- a/tests/test_weighted_reg.py
+++ b/tests/test_weighted_reg.py
@@ -44,7 +44,7 @@ class TestWeightedReg(unittest.TestCase):
         cop2.fittedParams = [-0.7]
 
         # draw 1000 samples from each model
-        n = 1000
+        n = 4000
         x1, y1 = cop1.sampleScale(marg1, marg2, n)
         x2, y2 = cop2.sampleScale(marg1, marg2, n)
 


### PR DESCRIPTION
- Computes ranked samples on demand.  In order to reduce memory consumption: Do not store ranked values.