### PR TITLE
Clean numpy install in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 env:
     - MPLBACKEND="agg"
 install:
+    - pip uninstall numpy -y
     - pip install coveralls pytest-cov
     - pip install dcor
     - pip install -r requirements.txt


### PR DESCRIPTION
- Fix failing build on travis CI for python2.7 due to numpy import error:

```
    import numpy as np
../../../virtualenv/python2.7.15/lib/python2.7/site-packages/statsmodels/compat/numpy.py:46: in <module>
    NP_LT_114 = LooseVersion(np.__version__) < LooseVersion('1.14')
E   AttributeError: 'module' object has no attribute '__version__'
```