### PR TITLE
Fix for MLE copula fit

### DIFF
--- a/starvine/bvcopula/copula/copula_base.py
+++ b/starvine/bvcopula/copula/copula_base.py
@@ -184,7 +184,7 @@ class CopulaBase(object):
                      x0=params0,
                      bounds=kwargs.pop("bounds", self.thetaBounds),
                      tol=kwargs.pop("tol", 1e-8),
-                     method=kwargs.pop("method", 'SLSQP'))
+                     method=kwargs.pop("method", 'trust-constr'))
         if not res.success:
             # Fallback
             if "frank" in self.name:

--- a/starvine/bvcopula/copula/mvtdstpack/mvtdstpack.f
+++ b/starvine/bvcopula/copula/mvtdstpack/mvtdstpack.f
@@ -1329,7 +1329,7 @@
 *          estimated absolute accuracy ABSERR.
 ************************************************************************
       EXTERNAL FUNSUB
-      DOUBLE PRECISION ABSEPS, RELEPS, FINEST(*), ABSERR, ONE
+      DOUBLE PRECISION ABSEPS, RELEPS, FINEST(*), ABSERR(1), ONE
       INTEGER NDIM, NF, MINVLS, MAXVLS, INFORM, NP, PLIM, KLIM,
      &        NLIM, FLIM, SAMPLS, I, K, INTVLS, MINSMP, KMX
       PARAMETER ( PLIM = 28, NLIM = 1000, KLIM = 100, FLIM = 5000 )
@@ -1387,8 +1387,8 @@
          IF ( VARSQR(K) .GT. 0 ) VAREST(K) = ( 1 + VARPRD )/VARSQR(K)
          IF ( ABS(FINEST(K)) .GT. ABS(FINEST(KMX)) ) KMX = K
       END DO
-      ABSERR = 7*SQRT( VARSQR(KMX)/( 1 + VARPRD ) )/2
-      IF ( ABSERR .GT. MAX( ABSEPS, ABS(FINEST(KMX))*RELEPS ) ) THEN
+      ABSERR(1) = 7*SQRT( VARSQR(KMX)/( 1 + VARPRD ) )/2
+      IF ( ABSERR(1) .GT. MAX( ABSEPS, ABS(FINEST(KMX))*RELEPS ) ) THEN
          IF ( NP .LT. PLIM ) THEN
             NP = NP + 1
          ELSE


### PR DESCRIPTION
Move from SLSQP to trus-constr as default minimizer for MLE copula fit.

Error encountered in scipy v 1.5.1  with SLSQP minimizer stepping out of bound-constraints.  (older version of scipy <= 1.4.X work fine).

```
        if np.any((x0 < lb) | (x0 > ub)):
>           raise ValueError("`x0` violates bound constraints.")
E           ValueError: `x0` violates bound constraints.

../../../miniconda3/lib/python3.8/site-packages/scipy/optimize/_numdiff.py:391: ValueError
```
