### PR TITLE
remove use of depreciated stat_func in seaborn plot

### DIFF
--- a/starvine/bvcopula/bv_plot.py
+++ b/starvine/bvcopula/bv_plot.py
@@ -43,7 +43,8 @@ def bvJointPlot(u, v, corr_stat="kendalltau", vs=None, **kwargs):
                   "spearmanr": spearmanr,
                   "pearsonr": pearsonr}
     outfile = kwargs.pop("savefig", None)
-    joint_plt = sns.jointplot(x=u, y=v, stat_func=stat_funcs[corr_stat], zorder=2, label="resampled", **kwargs)
+    joint_plt = sns.jointplot(x=u, y=v, zorder=2, label="resampled", **kwargs)
+    # joint_plt.annotate(stat_funcs[corr_stat])
     vsData = vs
     if vsData is not None:
         joint_plt.x, joint_plt.y = vsData[0], vsData[1]

--- a/starvine/bvcopula/tests/test_gauss_rotate.py
+++ b/starvine/bvcopula/tests/test_gauss_rotate.py
@@ -22,7 +22,7 @@ class TestRotateGauss(unittest.TestCase):
         for rotation, shapeParam in iteritems(shapes):
             gauss = Copula("gauss", 0)
             u, v = gauss.sample(10000, *(shapeParam,))
-            g = sns.jointplot(u, v, stat_func=kendalltau)
+            g = sns.jointplot(u, v)
             g.savefig("gauss_sample_pdf_" + str(rotation) + ".png")
             gauss.fittedParams = (shapeParam,)
             c_kTau = gauss.kTau()
@@ -43,5 +43,5 @@ class TestRotateGauss(unittest.TestCase):
             self.assertAlmostEqual(c_kTau, gauss_refit.copulaModel.kTau(), delta=0.05)
             self.assertAlmostEqual(shapeParam, gauss_refit.copulaParams[1][0], delta=0.2)
             # plot resampled data
-            g_resample = sns.jointplot(u_resample, v_resample, stat_func=kendalltau)
+            g_resample = sns.jointplot(u_resample, v_resample)
             g_resample.savefig("gauss_resample_pdf_" + str(rotation) + ".png")

--- a/starvine/bvcopula/tests/test_rotation_clayton.py
+++ b/starvine/bvcopula/tests/test_rotation_clayton.py
@@ -35,7 +35,7 @@ class TestRotateArchimedeanCopula(unittest.TestCase):
         for rotation, expectedKtau in iteritems(expectedKtaus):
             clayton = Copula("clayton", rotation)
             u, v = clayton.sample(40000, *(shapeParam,))
-            g = sns.jointplot(u, v, stat_func=kendalltau)
+            g = sns.jointplot(u, v)
             g.savefig("clayton_sample_pdf_" + str(rotation) + ".png")
             clayton.fittedParams = (shapeParam,)
             c_kTau = clayton.kTau()
@@ -58,5 +58,5 @@ class TestRotateArchimedeanCopula(unittest.TestCase):
             u_resample, v_resample = clayton_refit.copulaModel.sample(1000)
             self.assertAlmostEqual(c_kTau, clayton_refit.copulaModel.kTau(), delta=0.05)
             # plot resampled data
-            g_resample = sns.jointplot(u_resample, v_resample, stat_func=kendalltau)
+            g_resample = sns.jointplot(u_resample, v_resample)
             g_resample.savefig("clayton_resample_pdf_" + str(rotation) + ".png")

--- a/starvine/bvcopula/tests/test_rotation_frank.py
+++ b/starvine/bvcopula/tests/test_rotation_frank.py
@@ -31,7 +31,7 @@ class TestRotateFrankCopula(unittest.TestCase):
         for rotation, expectedKtau in iteritems(expectedKtaus):
             frank = Copula("frank", rotation)
             u, v = frank.sample(10000, *(shapeParam,))
-            g = sns.jointplot(u, v, stat_func=kendalltau)
+            g = sns.jointplot(u, v)
             g.savefig("frank_sample_pdf_" + str(rotation) + ".png")
             frank.fittedParams = (shapeParam,)
             c_kTau = frank.kTau()
@@ -53,5 +53,5 @@ class TestRotateFrankCopula(unittest.TestCase):
             u_resample, v_resample = frank_refit.copulaModel.sample(1000)
             self.assertAlmostEqual(c_kTau, frank_refit.copulaModel.kTau(), delta=0.05)
             # plot resampled data
-            g_resample = sns.jointplot(u_resample, v_resample, stat_func=kendalltau)
+            g_resample = sns.jointplot(u_resample, v_resample)
             g_resample.savefig("frank_resample_pdf_" + str(rotation) + ".png")

--- a/starvine/bvcopula/tests/test_rotation_gumbel.py
+++ b/starvine/bvcopula/tests/test_rotation_gumbel.py
@@ -29,7 +29,7 @@ class TestRotateArchimedeanCopula(unittest.TestCase):
         for rotation, expectedKtau in iteritems(expectedKtaus):
             gumbel = Copula("gumbel", rotation)
             u, v = gumbel.sample(40000, *(shapeParam,))
-            g = sns.jointplot(u, v, stat_func=kendalltau)
+            g = sns.jointplot(u, v)
             g.savefig("gumbel_sample_pdf_" + str(rotation) + ".png")
             gumbel.fittedParams = (shapeParam,)
             c_kTau = gumbel.kTau()
@@ -52,5 +52,5 @@ class TestRotateArchimedeanCopula(unittest.TestCase):
             u_resample, v_resample = gumbel_refit.copulaModel.sample(4000)
             self.assertAlmostEqual(c_kTau, gumbel_refit.copulaModel.kTau(), delta=0.05)
             # plot resampled data
-            g_resample = sns.jointplot(u_resample, v_resample, stat_func=kendalltau)
+            g_resample = sns.jointplot(u_resample, v_resample)
             g_resample.savefig("gumbel_resample_pdf_" + str(rotation) + ".png")

--- a/starvine/bvcopula/tests/test_t_copula_fit.py
+++ b/starvine/bvcopula/tests/test_t_copula_fit.py
@@ -31,14 +31,14 @@ class TestTcopulaFit(unittest.TestCase):
 
         # plot dataset for visual inspection
         marg_dict = {}
-        plt0 = sns.jointplot(x, y, marginal_kws=marg_dict, stat_func=kendalltau)
+        plt0 = sns.jointplot(x, y, marginal_kws=marg_dict)
         plt0.savefig("original_stocks.png")
         bvPairPlot(x, y, savefig="original_stocks_pair.png")
 
         # Rank transform the data
         u = rankdata(x) / (len(x) + 1)
         v = rankdata(y) / (len(y) + 1)
-        plt1 = sns.jointplot(u, v, marginal_kws=marg_dict, stat_func=kendalltau)
+        plt1 = sns.jointplot(u, v, marginal_kws=marg_dict)
         plt1.savefig("rank_transformed.png")
 
         # CDF tranformed data
@@ -49,7 +49,7 @@ class TestTcopulaFit(unittest.TestCase):
         for i, (xp, yp) in enumerate(zip(x, y)):
             u_c[i] = kde_x.integrate_box_1d(-np.inf, xp)
             v_c[i] = kde_y.integrate_box_1d(-np.inf, yp)
-        plt11 = sns.jointplot(u_c, v_c, marginal_kws=marg_dict, stat_func=kendalltau)
+        plt11 = sns.jointplot(u_c, v_c, marginal_kws=marg_dict)
         plt11.savefig("cdf_transformed.png")
 
         # Fit t copula and gaussian copula
@@ -74,13 +74,13 @@ class TestTcopulaFit(unittest.TestCase):
         # Sample from the fitted gaussian copula and plot
         ug_hat, vg_hat = g_copula.sample(1000, *theta_g_fit)
         pl.figure(2)
-        plt2 = sns.jointplot(ug_hat, vg_hat, stat_func=kendalltau)
+        plt2 = sns.jointplot(ug_hat, vg_hat)
         plt2.savefig("gaussian_copula_hat.png")
 
         # Sample from the fitted t copula and plot
         ut_hat, vt_hat = t_copula.sample(1000, *theta_t_fit)
         pl.figure(3)
-        plt3 = sns.jointplot(ut_hat, vt_hat, stat_func=kendalltau)
+        plt3 = sns.jointplot(ut_hat, vt_hat)
         plt3.savefig("t_copula_hat.png")
 
         # Resample original data
@@ -99,7 +99,7 @@ class TestTcopulaFit(unittest.TestCase):
             return icdf
         resampled_x = icdf_uv_bisect(x, ut_hat)
         resampled_y = icdf_uv_bisect(y, vt_hat)
-        plt5 = sns.jointplot(resampled_x, resampled_y, stat_func=kendalltau)
+        plt5 = sns.jointplot(resampled_x, resampled_y)
         plt5.savefig("resampled_scatter.png")
 
         # Compare to expected results


### PR DESCRIPTION
Remove use of `stat_func` in seaborn plots.  This was deprecated in seaborn 0.11.